### PR TITLE
FIX #376 Made the Dock animation running

### DIFF
--- a/registry/default/magicui/dock.tsx
+++ b/registry/default/magicui/dock.tsx
@@ -2,7 +2,7 @@
 
 import React, { PropsWithChildren, useRef } from "react";
 import { cva, type VariantProps } from "class-variance-authority";
-import { motion, useMotionValue, useSpring, useTransform } from "framer-motion";
+import {motion, MotionValue, useSpring, useTransform} from "framer-motion";
 
 import { cn } from "@/lib/utils";
 
@@ -10,12 +10,14 @@ export interface DockProps extends VariantProps<typeof dockVariants> {
   className?: string;
   magnification?: number;
   distance?: number;
+  mouseX?: MotionValue;
   direction?: "top" | "middle" | "bottom";
   children: React.ReactNode;
 }
 
 const DEFAULT_MAGNIFICATION = 60;
 const DEFAULT_DISTANCE = 140;
+
 
 const dockVariants = cva(
   "supports-backdrop-blur:bg-white/10 supports-backdrop-blur:dark:bg-black/10 mx-auto mt-8 flex h-[58px] w-max gap-2 rounded-2xl border p-2 backdrop-blur-md",
@@ -28,12 +30,13 @@ const Dock = React.forwardRef<HTMLDivElement, DockProps>(
       children,
       magnification = DEFAULT_MAGNIFICATION,
       distance = DEFAULT_DISTANCE,
+      mouseX,
       direction = "bottom",
       ...props
     },
     ref,
   ) => {
-    const mouseX = useMotionValue(Infinity);
+    // const mouseX = useMotionValue(Infinity);
 
     const renderChildren = () => {
       return React.Children.map(children, (child) => {
@@ -73,7 +76,7 @@ export interface DockIconProps {
   size?: number;
   magnification?: number;
   distance?: number;
-  mouseX?: any;
+  mouseX?: MotionValue;
   className?: string;
   children?: React.ReactNode;
   props?: PropsWithChildren;
@@ -89,7 +92,6 @@ const DockIcon = ({
   ...props
 }: DockIconProps) => {
   const ref = useRef<HTMLDivElement>(null);
-
   const distanceCalc = useTransform(mouseX, (val: number) => {
     const bounds = ref.current?.getBoundingClientRect() ?? { x: 0, width: 0 };
 


### PR DESCRIPTION
I have fixed the mouseX bug where mouseX would be undefined by passing mouseX to both `Dock` and `DockIcon`

Now you can easily have the `Dock `and `DockIcon` animate as you hover the cursor over the **_Dock_** and its icons.